### PR TITLE
feat(yandex-metrika): track router pageviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,21 @@
 ✅ Поддержка нескольких счетчиков  
 ✅ Окружение-зависимая инициализация (режим prodOnly)  
 ✅ NoScript фолбэк для пользователей с отключенным JavaScript  
-✅ Простой паттерн провайдеров
+✅ Простой паттерн провайдеров  
+✅ Отложенная инициализация до согласия (GDPR / 152-ФЗ), `initialization: 'deferred'`  
+✅ Автоматические virtual pageview при навигации SPA — `provideYandexMetrikaRouter()`
+
+---
+
+## Обновления в версии 1.7.0
+
+**`provideYandexMetrikaRouter()`** — `NavigationEnd` → `hit(urlAfterRedirects)`; опции `ignoreInitialNavigation` (по умолчанию `true`), `includePageTitle` (по умолчанию `true`). Подключайте **после** `provideYandexMetrika` и `provideRouter`. Совместимо с `initialization: 'deferred'`. Требуются peer-зависимости `@angular/router` и `@angular/platform-browser`. Развёрнутая инструкция: [projects/yandex-metrika/README.md](projects/yandex-metrika/README.md).
+
+---
+
+## Обновления в версии 1.6.0
+
+**Отложенная инициализация** — второй аргумент `provideYandexMetrika(config, { initialization: 'deferred' })` и `YMInitService.initializeAll()` после согласия. См. `includeNoscriptFallback: false` для баннера.
 
 ---
 

--- a/angular.json
+++ b/angular.json
@@ -24,7 +24,8 @@
         "test": {
           "builder": "@angular/build:karma",
           "options": {
-            "tsConfig": "projects/yandex-metrika/tsconfig.spec.json"
+            "tsConfig": "projects/yandex-metrika/tsconfig.spec.json",
+            "polyfills": ["zone.js", "zone.js/testing"]
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,18 +36,21 @@
         "karma-jasmine-html-reporter": "~2.1.0",
         "ng-packagr": "^20.2.0",
         "prettier": "^3.6.2",
-        "typescript": "~5.9.2"
+        "typescript": "~5.9.2",
+        "zone.js": "^0.15.0"
       }
     },
     "dist/@grandgular/yandex-metrika": {
-      "version": "1.1.1",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/common": "^19.0.0 || ^20.0.0",
-        "@angular/core": "^19.0.0 || ^20.0.0"
+        "@angular/common": "^19.0.0 || ^20.0.0 || ^21.0.0",
+        "@angular/core": "^19.0.0 || ^20.0.0 || ^21.0.0",
+        "@angular/platform-browser": "^19.0.0 || ^20.0.0 || ^21.0.0",
+        "@angular/router": "^19.0.0 || ^20.0.0 || ^21.0.0"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -10532,6 +10535,13 @@
       "peerDependencies": {
         "zod": "^3.24.1"
       }
+    },
+    "node_modules/zone.js": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.0.tgz",
+      "integrity": "sha512-9oxn0IIjbCZkJ67L+LkhYWRyAy7axphb3VgE2MBDlOqnmHMPWGYMxJxBYFueFq/JGY2GMwS0rU+UCLunEmy5UA==",
+      "devOptional": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "karma-jasmine-html-reporter": "~2.1.0",
     "ng-packagr": "^20.2.0",
     "prettier": "^3.6.2",
-    "typescript": "~5.9.2"
+    "typescript": "~5.9.2",
+    "zone.js": "^0.15.0"
   }
 }

--- a/projects/showcase/src/app/app.config.ts
+++ b/projects/showcase/src/app/app.config.ts
@@ -7,8 +7,8 @@ import { provideRouter } from '@angular/router';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
 import { provideHttpClient, withFetch } from '@angular/common/http';
 import { routes } from './app.routes';
-// import { provideYandexMetrika } from '@grandgular/yandex-metrika';
-import { provideYandexMetrika } from '../../../yandex-metrika/src/lib/ym-provider';
+// import { provideYandexMetrika, provideYandexMetrikaRouter } from '@grandgular/yandex-metrika';
+import { provideYandexMetrika, provideYandexMetrikaRouter } from '../../../yandex-metrika/src/public-api';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -32,5 +32,6 @@ export const appConfig: ApplicationConfig = {
       },
       { initialization: 'deferred' },
     ),
+    provideYandexMetrikaRouter(),
   ],
 };

--- a/projects/yandex-metrika/README.md
+++ b/projects/yandex-metrika/README.md
@@ -20,7 +20,36 @@
 ✅ Окружение-зависимая инициализация (режим prodOnly)  
 ✅ NoScript фолбэк для пользователей с отключенным JavaScript  
 ✅ Простой паттерн провайдеров  
-✅ **Отложенная инициализация до согласия (GDPR / 152-ФЗ)** — новое в v1.6.0
+✅ **Отложенная инициализация до согласия (GDPR / 152-ФЗ)**  
+✅ **Автоматические virtual pageview при смене маршрута (SPA)** — `provideYandexMetrikaRouter()`
+
+---
+
+## Обновления в версии 1.7.0
+
+**`provideYandexMetrikaRouter()`** — подписка на `Router.events` (`NavigationEnd`) и вызов `hit()` с `urlAfterRedirects` (и при необходимости заголовком страницы). Добавьте **после** `provideYandexMetrika` и `provideRouter`.
+
+```typescript
+import { ApplicationConfig } from '@angular/core';
+import { provideRouter, Routes } from '@angular/router';
+import { provideYandexMetrika, provideYandexMetrikaRouter } from '@grandgular/yandex-metrika';
+
+const routes: Routes = [];
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideRouter(routes),
+    provideYandexMetrika({ id: 123456, options: { trackHash: true } }),
+    provideYandexMetrikaRouter({
+      ignoreInitialNavigation: true, // не дублировать первый просмотр (по умолчанию)
+      includePageTitle: true,        // передавать title в hit (по умолчанию)
+    }),
+  ],
+};
+```
+
+- Совместим с `initialization: 'deferred'`: до `initializeAll()` вызовы `hit` из трекера отработают как no-op.
+- **Peer-зависимости** для этой фичи: `@angular/router`, `@angular/platform-browser` (уже в peer-диапазоне пакета).
 
 ---
 

--- a/projects/yandex-metrika/package.json
+++ b/projects/yandex-metrika/package.json
@@ -1,9 +1,11 @@
 {
   "name": "@grandgular/yandex-metrika",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "peerDependencies": {
-    "@angular/common": "^19.0.0 || ^20.0.0",
-    "@angular/core": "^19.0.0 || ^20.0.0"
+    "@angular/common": "^19.0.0 || ^20.0.0 || ^21.0.0",
+    "@angular/core": "^19.0.0 || ^20.0.0 || ^21.0.0",
+    "@angular/platform-browser": "^19.0.0 || ^20.0.0 || ^21.0.0",
+    "@angular/router": "^19.0.0 || ^20.0.0 || ^21.0.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/projects/yandex-metrika/src/lib/ym-init-service.spec.ts
+++ b/projects/yandex-metrika/src/lib/ym-init-service.spec.ts
@@ -1,0 +1,61 @@
+import { DOCUMENT } from '@angular/common';
+import { TestBed } from '@angular/core/testing';
+import { PLATFORM_ID } from '@angular/core';
+import { YM_CONFIG_TOKEN } from './ym-config-token';
+import { YMInitService } from './ym-init-service';
+
+describe('YMInitService', () => {
+  const originalYm = (globalThis as unknown as { ym?: unknown }).ym;
+  const cfg = { id: 5005, prodOnly: false, includeNoscriptFallback: false as const };
+
+  afterEach(() => {
+    if (originalYm === undefined) {
+      delete (globalThis as unknown as { ym?: unknown }).ym;
+    } else {
+      (globalThis as unknown as { ym: unknown }).ym = originalYm;
+    }
+  });
+
+  function makeInit(platformId: string) {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: YM_CONFIG_TOKEN, useValue: [cfg] },
+        { provide: PLATFORM_ID, useValue: platformId },
+        YMInitService,
+      ],
+    });
+    return TestBed.inject(YMInitService);
+  }
+
+  it('на сервере не вставляет скрипт', () => {
+    const service = makeInit('server');
+    const doc = TestBed.inject(DOCUMENT);
+    const head = doc.head;
+    const before = head.querySelectorAll('script').length;
+    service.initialize(cfg);
+    expect(head.querySelectorAll('script').length).toBe(before);
+  });
+
+  it('в браузере инициализирует очередь ym и register init', () => {
+    delete (globalThis as unknown as { ym?: unknown }).ym;
+    const service = makeInit('browser');
+    service.initialize(cfg);
+    const ym = (globalThis as unknown as { ym: (id: number, a: string, b: unknown) => void }).ym;
+    expect(typeof ym).toBe('function');
+  });
+
+  it('initialize дважды с тем же id не дублирует тег script', () => {
+    delete (globalThis as unknown as { ym?: unknown }).ym;
+    const service = makeInit('browser');
+    const doc = TestBed.inject(DOCUMENT);
+    const sel = 'script[src="https://mc.yandex.ru/metrika/tag.js"]';
+    const n0 = doc.querySelectorAll(sel).length;
+    service.initialize(cfg);
+    const n1 = doc.querySelectorAll(sel).length;
+    service.initialize(cfg);
+    const n2 = doc.querySelectorAll(sel).length;
+    expect(n1 - n0).toBe(1);
+    expect(n2).toBe(n1);
+  });
+});

--- a/projects/yandex-metrika/src/lib/ym-provider.spec.ts
+++ b/projects/yandex-metrika/src/lib/ym-provider.spec.ts
@@ -1,0 +1,38 @@
+import { TestBed } from '@angular/core/testing';
+import { YM_CONFIG_TOKEN, YM_DEFAULT_CONFIG_TOKEN } from './ym-config-token';
+import { provideYandexMetrika } from './ym-provider';
+import { provideYandexMetrikaRouter } from './ym-router-provider';
+import { YandexMetrikaRouterTracker } from './ym-router-tracker.service';
+import { Subject } from 'rxjs';
+import { Router } from '@angular/router';
+import { Title } from '@angular/platform-browser';
+
+describe('provideYandexMetrika', () => {
+  it('deferred: регистрирует массив конфигов и default-счётчик', () => {
+    TestBed.configureTestingModule({
+      providers: [provideYandexMetrika([{ id: 11, name: 'a', default: true }], { initialization: 'deferred' })],
+    });
+    const configs = TestBed.inject(YM_CONFIG_TOKEN);
+    expect(configs.length).toBe(1);
+    expect(TestBed.inject(YM_DEFAULT_CONFIG_TOKEN)?.id).toBe(11);
+  });
+});
+
+describe('provideYandexMetrikaRouter', () => {
+  it('создаёт YandexMetrikaRouterTracker (вместе с provideYandexMetrika + mock Router)', () => {
+    const ev = new Subject<unknown>();
+    TestBed.configureTestingModule({
+      providers: [
+        provideYandexMetrika(
+          { id: 1, name: 'm', default: true, prodOnly: false },
+          { initialization: 'deferred' },
+        ),
+        provideYandexMetrikaRouter(),
+        { provide: Router, useValue: { events: ev.asObservable() } },
+        { provide: Title, useValue: { getTitle: () => 'T' } },
+      ],
+    });
+    const tracker = TestBed.inject(YandexMetrikaRouterTracker);
+    expect(tracker).toBeTruthy();
+  });
+});

--- a/projects/yandex-metrika/src/lib/ym-router-options.ts
+++ b/projects/yandex-metrika/src/lib/ym-router-options.ts
@@ -1,0 +1,42 @@
+import { InjectionToken } from '@angular/core';
+
+/**
+ * Опции {@link provideYandexMetrikaRouter} для учёта virtual pageview при навигации SPA.
+ */
+export interface YandexMetrikaRouterOptions {
+  /**
+   * Пропустить первый `NavigationEnd` (обычно совпадает с первой загрузкой),
+   * чтобы не дублировать просмотр, который уже уходит при инициализации счётчика.
+   *
+   * @default true
+   */
+  ignoreInitialNavigation?: boolean;
+
+  /**
+   * Передавать в {@link YMService.hit} текущий заголовок окна (`Title.getTitle()`)
+   * в поле `title` второго аргумента.
+   *
+   * @default true
+   */
+  includePageTitle?: boolean;
+}
+
+/**
+ * @internal
+ */
+export type YandexMetrikaRouterOptionsResolved = Readonly<{
+  ignoreInitialNavigation: boolean;
+  includePageTitle: boolean;
+}>;
+
+export const YM_DEFAULT_ROUTER_OPTIONS: YandexMetrikaRouterOptionsResolved = {
+  ignoreInitialNavigation: true,
+  includePageTitle: true,
+};
+
+/**
+ * @internal
+ */
+export const YM_ROUTER_OPTIONS = new InjectionToken<YandexMetrikaRouterOptionsResolved>(
+  'YM_ROUTER_OPTIONS',
+);

--- a/projects/yandex-metrika/src/lib/ym-router-provider.ts
+++ b/projects/yandex-metrika/src/lib/ym-router-provider.ts
@@ -1,0 +1,37 @@
+import { EnvironmentProviders, inject, makeEnvironmentProviders, provideAppInitializer } from '@angular/core';
+import { YM_DEFAULT_ROUTER_OPTIONS, YM_ROUTER_OPTIONS, YandexMetrikaRouterOptions } from './ym-router-options';
+import { YandexMetrikaRouterTracker } from './ym-router-tracker.service';
+
+/**
+ * Подключает автоматическую отправку virtual pageview в Яндекс.Метрику при навигации
+ * (событие `NavigationEnd` → {@link YMService.hit}).
+ *
+ * Поместите **после** {@link provideYandexMetrika} в `ApplicationConfig`, чтобы
+ * `YMService` и счётчики были настроены.
+ *
+ * @example
+ * ```typescript
+ * export const appConfig: ApplicationConfig = {
+ *   providers: [
+ *     provideYandexMetrika({ id: 123, options: { defer: true } }),
+ *     provideYandexMetrikaRouter({ ignoreInitialNavigation: true }),
+ *   ],
+ * };
+ * ```
+ */
+export function provideYandexMetrikaRouter(
+  options?: YandexMetrikaRouterOptions,
+): EnvironmentProviders {
+  const resolved = { ...YM_DEFAULT_ROUTER_OPTIONS, ...options };
+
+  return makeEnvironmentProviders([
+    { provide: YM_ROUTER_OPTIONS, useValue: resolved },
+    YandexMetrikaRouterTracker,
+    provideAppInitializer(() => {
+      inject(YandexMetrikaRouterTracker);
+      return Promise.resolve();
+    }),
+  ]);
+}
+
+export type { YandexMetrikaRouterOptions } from './ym-router-options';

--- a/projects/yandex-metrika/src/lib/ym-router-tracker.service.spec.ts
+++ b/projects/yandex-metrika/src/lib/ym-router-tracker.service.spec.ts
@@ -1,0 +1,125 @@
+import { TestBed } from '@angular/core/testing';
+import { PLATFORM_ID } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+import { NavigationEnd, Router } from '@angular/router';
+import { Subject } from 'rxjs';
+import { YM_DEFAULT_CONFIG_TOKEN, YM_CONFIG_TOKEN } from './ym-config-token';
+import { YM_DEFAULT_ROUTER_OPTIONS, YM_ROUTER_OPTIONS } from './ym-router-options';
+import { YandexMetrikaRouterTracker } from './ym-router-tracker.service';
+import { YMService } from './ym-service';
+
+describe('YandexMetrikaRouterTracker', () => {
+  const defaultConfig = { id: 9001, name: 'm', default: true, prodOnly: false as const };
+  let events$: Subject<unknown>;
+  let ymMock: jasmine.Spy;
+  const originalYm = (globalThis as unknown as { ym?: unknown }).ym;
+  const titleGetTitle = jasmine.createSpy('getTitle').and.returnValue('TestTitle');
+
+  beforeEach(() => {
+    events$ = new Subject();
+    ymMock = jasmine.createSpy('ym');
+    (globalThis as unknown as { ym: typeof ymMock }).ym = ymMock;
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: YM_CONFIG_TOKEN, useValue: [defaultConfig] },
+        { provide: YM_DEFAULT_CONFIG_TOKEN, useValue: defaultConfig },
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: Router, useValue: { events: events$.asObservable() } },
+        { provide: Title, useValue: { getTitle: titleGetTitle } },
+        {
+          provide: YM_ROUTER_OPTIONS,
+          useValue: { ...YM_DEFAULT_ROUTER_OPTIONS },
+        },
+        YMService,
+        YandexMetrikaRouterTracker,
+      ],
+    });
+  });
+
+  afterEach(() => {
+    if (originalYm === undefined) {
+      delete (globalThis as unknown as { ym?: unknown }).ym;
+    } else {
+      (globalThis as unknown as { ym: unknown }).ym = originalYm;
+    }
+  });
+
+  it('первый NavigationEnd пропускается при ignoreInitialNavigation: true', () => {
+    TestBed.inject(YandexMetrikaRouterTracker);
+    events$.next(new NavigationEnd(0, '/a', '/a'));
+    expect(ymMock).not.toHaveBeenCalled();
+  });
+
+  it('второй NavigationEnd вызывает hit с url и title', () => {
+    TestBed.inject(YandexMetrikaRouterTracker);
+    events$.next(new NavigationEnd(0, '/a', '/a'));
+    events$.next(new NavigationEnd(1, '/a', '/b'));
+    expect(ymMock).toHaveBeenCalledWith(
+      9001,
+      'hit',
+      '/b',
+      jasmine.objectContaining({ title: 'TestTitle' }),
+    );
+  });
+
+  it('с ignoreInitialNavigation: false с первого события шлёт hit', () => {
+    TestBed.resetTestingModule();
+    events$ = new Subject();
+    ymMock = jasmine.createSpy('ym');
+    (globalThis as unknown as { ym: typeof ymMock }).ym = ymMock;
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: YM_CONFIG_TOKEN, useValue: [defaultConfig] },
+        { provide: YM_DEFAULT_CONFIG_TOKEN, useValue: defaultConfig },
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: Router, useValue: { events: events$.asObservable() } },
+        { provide: Title, useValue: { getTitle: titleGetTitle } },
+        {
+          provide: YM_ROUTER_OPTIONS,
+          useValue: { ignoreInitialNavigation: false, includePageTitle: true },
+        },
+        YMService,
+        YandexMetrikaRouterTracker,
+      ],
+    });
+    TestBed.inject(YandexMetrikaRouterTracker);
+    events$.next(new NavigationEnd(0, '/a', '/a'));
+    expect(ymMock).toHaveBeenCalled();
+  });
+
+  it('с includePageTitle: false hit без поля title', () => {
+    TestBed.resetTestingModule();
+    events$ = new Subject();
+    ymMock = jasmine.createSpy('ym');
+    (globalThis as unknown as { ym: typeof ymMock }).ym = ymMock;
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: YM_CONFIG_TOKEN, useValue: [defaultConfig] },
+        { provide: YM_DEFAULT_CONFIG_TOKEN, useValue: defaultConfig },
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: Router, useValue: { events: events$.asObservable() } },
+        { provide: Title, useValue: { getTitle: titleGetTitle } },
+        {
+          provide: YM_ROUTER_OPTIONS,
+          useValue: { ignoreInitialNavigation: true, includePageTitle: false },
+        },
+        YMService,
+        YandexMetrikaRouterTracker,
+      ],
+    });
+    TestBed.inject(YandexMetrikaRouterTracker);
+    events$.next(new NavigationEnd(0, '/a', '/a'));
+    events$.next(new NavigationEnd(1, '/a', '/b'));
+    expect(ymMock).toHaveBeenCalledWith(9001, 'hit', '/b');
+  });
+
+  it('ngOnDestroy отписывается', () => {
+    const tracker = TestBed.inject(YandexMetrikaRouterTracker);
+    events$.next(new NavigationEnd(0, '/a', '/a'));
+    events$.next(new NavigationEnd(1, '/a', '/b'));
+    ymMock.calls.reset();
+    tracker.ngOnDestroy();
+    events$.next(new NavigationEnd(2, '/b', '/c'));
+    expect(ymMock).not.toHaveBeenCalled();
+  });
+});

--- a/projects/yandex-metrika/src/lib/ym-router-tracker.service.ts
+++ b/projects/yandex-metrika/src/lib/ym-router-tracker.service.ts
@@ -1,0 +1,53 @@
+import { isPlatformBrowser } from '@angular/common';
+import { inject, Injectable, OnDestroy, PLATFORM_ID } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+import { NavigationEnd, Router } from '@angular/router';
+import { filter, Subscription } from 'rxjs';
+import { YM_ROUTER_OPTIONS } from './ym-router-options';
+import { YMService } from './ym-service';
+
+/**
+ * Подписка на `Router.events` и отправка virtual pageview через {@link YMService.hit}
+ * (см. {@link provideYandexMetrikaRouter}).
+ *
+ * @internal
+ */
+@Injectable()
+export class YandexMetrikaRouterTracker implements OnDestroy {
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly router = inject(Router);
+  private readonly ym = inject(YMService);
+  private readonly title = inject(Title);
+  private readonly config = inject(YM_ROUTER_OPTIONS);
+
+  private sub?: Subscription;
+  private initialEventHandled = false;
+
+  constructor() {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
+
+    this.sub = this.router.events
+      .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
+      .subscribe((e) => {
+        if (this.config.ignoreInitialNavigation && !this.initialEventHandled) {
+          this.initialEventHandled = true;
+          return;
+        }
+        this.initialEventHandled = true;
+
+        const url = e.urlAfterRedirects;
+        if (this.config.includePageTitle) {
+          this.ym.hit(url, { title: this.title.getTitle() });
+          return;
+        }
+
+        this.ym.hit(url);
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.sub?.unsubscribe();
+  }
+}

--- a/projects/yandex-metrika/src/lib/ym-service.spec.ts
+++ b/projects/yandex-metrika/src/lib/ym-service.spec.ts
@@ -1,0 +1,101 @@
+import { TestBed } from '@angular/core/testing';
+import { PLATFORM_ID } from '@angular/core';
+import { YM_DEFAULT_CONFIG_TOKEN, YM_CONFIG_TOKEN } from './ym-config-token';
+import { YMService } from './ym-service';
+import { YMMethod } from './ym-method-enum';
+
+describe('YMService', () => {
+  const defaultConfig = { id: 1001, name: 'main', default: true, prodOnly: false as const };
+  let ymMock: jasmine.Spy;
+  const originalYm = (globalThis as unknown as { ym?: unknown }).ym;
+
+  beforeEach(() => {
+    ymMock = jasmine.createSpy('ym');
+    (globalThis as unknown as { ym: typeof ymMock }).ym = ymMock;
+  });
+
+  afterEach(() => {
+    if (originalYm === undefined) {
+      delete (globalThis as unknown as { ym?: unknown }).ym;
+    } else {
+      (globalThis as unknown as { ym: unknown }).ym = originalYm;
+    }
+  });
+
+  function makeModule(platformId: string) {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: YM_CONFIG_TOKEN, useValue: [defaultConfig] },
+        { provide: YM_DEFAULT_CONFIG_TOKEN, useValue: defaultConfig },
+        { provide: PLATFORM_ID, useValue: platformId },
+        YMService,
+      ],
+    });
+    return TestBed.inject(YMService);
+  }
+
+  it('создаётся', () => {
+    const service = makeModule('browser');
+    expect(service).toBeTruthy();
+  });
+
+  it('на SSR не вызывает window.ym', () => {
+    const service = makeModule('server');
+    service.hit('/p');
+    expect(ymMock).not.toHaveBeenCalled();
+  });
+
+  it('для default-счётчика вызывает ym(id, method, ...args) для hit', () => {
+    const service = makeModule('browser');
+    service.hit('/path', { title: 'P' });
+    expect(ymMock).toHaveBeenCalledWith(1001, 'hit', '/path', jasmine.objectContaining({ title: 'P' }));
+  });
+
+  it('для reachGoal передаёт имя и параметры', () => {
+    const service = makeModule('browser');
+    service.reachGoal('order', { order_price: 10, currency: 'RUB' });
+    expect(ymMock).toHaveBeenCalledWith(1001, 'reachGoal', 'order', {
+      order_price: 10,
+      currency: 'RUB',
+    });
+  });
+
+  it('для hitWithCounter использует id счётчика', () => {
+    const secondary = { id: 2002, name: 'sec', default: false, prodOnly: false as const };
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: YM_CONFIG_TOKEN, useValue: [defaultConfig, secondary] },
+        { provide: YM_DEFAULT_CONFIG_TOKEN, useValue: defaultConfig },
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        YMService,
+      ],
+    });
+    const service = TestBed.inject(YMService);
+    service.hitWithCounter(2002, '/s');
+    expect(ymMock).toHaveBeenCalledWith(2002, 'hit', '/s');
+  });
+
+  it('без window.ym не падает', () => {
+    delete (globalThis as unknown as { ym?: unknown }).ym;
+    const service = makeModule('browser');
+    expect(() => service.execute(YMMethod.ReachGoal, 'x')).not.toThrow();
+  });
+
+  it('executeWithCounter с именем вызывает ym по id', () => {
+    const secondary = { id: 3003, name: 'named', default: false, prodOnly: false as const };
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: YM_CONFIG_TOKEN, useValue: [defaultConfig, secondary] },
+        { provide: YM_DEFAULT_CONFIG_TOKEN, useValue: defaultConfig },
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        YMService,
+      ],
+    });
+    const service = TestBed.inject(YMService);
+    service.executeWithCounter('named', 'params', { k: 1 });
+    expect(ymMock).toHaveBeenCalledWith(3003, 'params', { k: 1 });
+  });
+});

--- a/projects/yandex-metrika/src/public-api.ts
+++ b/projects/yandex-metrika/src/public-api.ts
@@ -2,4 +2,5 @@ export * from './lib/ym-config-interface';
 export * from './lib/ym-init-service';
 export * from './lib/ym-provider';
 export * from './lib/ym-provider-options';
+export { provideYandexMetrikaRouter, type YandexMetrikaRouterOptions } from './lib/ym-router-provider';
 export * from './lib/ym-service';


### PR DESCRIPTION
Add an optional router provider for SPA virtual pageviews and cover the new integration with library tests.